### PR TITLE
[CLOUD][Feat] 테라폼 backend 작성

### DIFF
--- a/envs/dev/.terraform.lock.hcl
+++ b/envs/dev/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.31.1"
+  constraints = "6.31.1"
+  hashes = [
+    "h1:vpj4yZQhk/eo5XROR2cHDbP7HS7FAq8lCgHdKQU/ouA=",
+    "zh:17e19d78ef84a41302ad905be768611ca695b013833d18bd9decce77496e1714",
+    "zh:23f4362695db5717e53124d92a936cbb6a4f9f90d222e188eb0d81fc1310ec60",
+    "zh:527dc043252727aa62788324d6d053fd738bacc529679126a32e4f28b49f2aa0",
+    "zh:541478997786be01be10cc0998b293354081dba007455cc3d161dcb289b1f730",
+    "zh:5a5b28b328a93a5fbd4f81e680f87e97acbbbefcb29c2f99e4d78bcb3b4cbd4b",
+    "zh:84ce98a2afb7a88441e7f34067edd358486a4ec1ad99be88edee6edb2eb90575",
+    "zh:85a0fef997b282fe70a0ceb547cf4e211cdf8bd7de4678b5ded0fc19bdf42a23",
+    "zh:8dd79251680e0a6145cb263ea1e9b66e522a015a266bda2b3bf14091f263fbf1",
+    "zh:97fb7721f442d07c8bf8d7055754023c2e8844e058a7b8cfc2df526df92ad0d0",
+    "zh:b6cbbcf0b070e8c3fa93cb3168c61ffa9ccad12adfa0d66143677ef1ec7e5dc3",
+    "zh:cde64ac1264d06fb376f66b9f8f96c5a8f7ab7ddbe554af736a54bbaac02c803",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -2,10 +2,14 @@ terraform {
   required_version = "1.11.4"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "6.31.1"
     }
-    
+  }
+  backend "gcs" {
+    bucket      = "dolpin-terraform-state-29m1t350"
+    prefix      = "dev"
+    credentials = "../../secrets/account.json"
   }
 }
 

--- a/envs/prod/.terraform.lock.hcl
+++ b/envs/prod/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.31.1"
+  constraints = "6.31.1"
+  hashes = [
+    "h1:vpj4yZQhk/eo5XROR2cHDbP7HS7FAq8lCgHdKQU/ouA=",
+    "zh:17e19d78ef84a41302ad905be768611ca695b013833d18bd9decce77496e1714",
+    "zh:23f4362695db5717e53124d92a936cbb6a4f9f90d222e188eb0d81fc1310ec60",
+    "zh:527dc043252727aa62788324d6d053fd738bacc529679126a32e4f28b49f2aa0",
+    "zh:541478997786be01be10cc0998b293354081dba007455cc3d161dcb289b1f730",
+    "zh:5a5b28b328a93a5fbd4f81e680f87e97acbbbefcb29c2f99e4d78bcb3b4cbd4b",
+    "zh:84ce98a2afb7a88441e7f34067edd358486a4ec1ad99be88edee6edb2eb90575",
+    "zh:85a0fef997b282fe70a0ceb547cf4e211cdf8bd7de4678b5ded0fc19bdf42a23",
+    "zh:8dd79251680e0a6145cb263ea1e9b66e522a015a266bda2b3bf14091f263fbf1",
+    "zh:97fb7721f442d07c8bf8d7055754023c2e8844e058a7b8cfc2df526df92ad0d0",
+    "zh:b6cbbcf0b070e8c3fa93cb3168c61ffa9ccad12adfa0d66143677ef1ec7e5dc3",
+    "zh:cde64ac1264d06fb376f66b9f8f96c5a8f7ab7ddbe554af736a54bbaac02c803",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -2,10 +2,14 @@ terraform {
   required_version = "1.11.4"
   required_providers {
     google = {
-      source = "hashicorp/google"
+      source  = "hashicorp/google"
       version = "6.31.1"
     }
-    
+  }
+  backend "gcs" {
+    bucket      = "dolpin-terraform-state-29m1t350"
+    prefix     = "prod"
+    credentials = "../../secrets/account.json"
   }
 }
 


### PR DESCRIPTION
## 📝 PR 개요
terraform backend를 gcs의 cloud storage를 사용하여 코드 작성

## 🔍 변경사항
- gcs의 cloud storage를 사용하여 terraform backend 적용
- prefix는 각환경에 맞는 dev, prod 사용
- credentials는 secrets하위의 account.json 파일 참조

## 🔗 관련 이슈
 #16 

## 🚨 주의사항
backend credentials 또한 provider와 마찬가지로 같은 account 사용