### PR TITLE
[CLOUD][Feat] Terraform network module 작성

### DIFF
--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,0 +1,14 @@
+resource "google_compute_network" "vpc" {
+  name                    = "vpc-${var.env}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnets" {
+  for_each = var.subnets
+
+  name          = each.key
+  ip_cidr_range = each.value.cidr
+  network       = google_compute_network.vpc.id
+  region        = var.region
+  private_ip_google_access = contains(["private"], each.value.type)
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -12,3 +12,9 @@ resource "google_compute_subnetwork" "subnets" {
   region        = var.region
   private_ip_google_access = contains(["private"], each.value.type)
 }
+
+resource "google_compute_router" "router" {
+  name          = "router-${var.env}"
+  region        = var.region
+  network       = google_compute_network.vpc.id
+}

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -9,12 +9,5 @@ resource "google_compute_subnetwork" "subnets" {
   name          = each.key
   ip_cidr_range = each.value.cidr
   network       = google_compute_network.vpc.id
-  region        = var.region
   private_ip_google_access = contains(["private"], each.value.type)
-}
-
-resource "google_compute_router" "router" {
-  name          = "router-${var.env}"
-  region        = var.region
-  network       = google_compute_network.vpc.id
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -1,0 +1,18 @@
+variable "env" {
+  description = "envs (dev, prod)"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast3"
+}
+
+variable "subnets" {
+  description = "subnet setting"
+  type        = map(object({
+    cidr = string
+    type = string # public or private
+  }))
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -10,7 +10,7 @@ variable "region" {
 }
 
 variable "subnets" {
-  description = "subnet setting"
+  description = "subnet setting. key=name, value={ cidr, type }"
   type        = map(object({
     cidr = string
     type = string # public or private


### PR DESCRIPTION
## 📝 PR 개요
GCP VPC, Subnet, Router 구성하는 Terraform 리소스 추가

## 🔍 변경사항
- google_compute_network: VPC 네트워크 리소스 생성
- google_compute_subnetwork: 서브넷을 for_each 기반으로 생성
- google_compute_router: 각 환경에 라우터 리소스 추가

## 🔗 관련 이슈
 #18 

## 🚨 주의사항
subnets 변수의 정의 형태는 다음과 같습니다.
```
subnets = {
  "public-subnet-1" = {
    cidr = "10.0.1.0/24"
    type = "public"
  },
  "private-subnet-1" = {
    cidr = "10.0.2.0/24"
    type = "private"
  }
}
```