### PR TITLE
Feat: public route, private route resource 추가

### DIFF
--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -14,7 +14,7 @@ resource "google_compute_subnetwork" "subnets" {
 
 resource "google_compute_route" "public_route" {
   name             = "public-route"
-  network          = google_compute_network.vpc.name
+  network          = google_compute_network.vpc.id
   dest_range       = "0.0.0.0/0"
   next_hop_gateway = "default-internet-gateway"
   priority         = 1000
@@ -23,7 +23,7 @@ resource "google_compute_route" "public_route" {
 
 resource "google_compute_route" "private_route" {
   name              = "private-route"
-  network           = google_compute_network.vpc.name
+  network           = google_compute_network.vpc.id
   dest_range        = "0.0.0.0/0"
   next_hop_instance = var.nat_link
   priority          = 1000

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -6,8 +6,26 @@ resource "google_compute_network" "vpc" {
 resource "google_compute_subnetwork" "subnets" {
   for_each = var.subnets
 
-  name          = each.key
-  ip_cidr_range = each.value.cidr
-  network       = google_compute_network.vpc.id
-  private_ip_google_access = contains(["private"], each.value.type)
+  name                     = each.key
+  ip_cidr_range            = each.value.cidr
+  network                  = google_compute_network.vpc.id
+  private_ip_google_access = false
+}
+
+resource "google_compute_route" "public_route" {
+  name             = "public-route"
+  network          = google_compute_network.vpc.name
+  dest_range       = "0.0.0.0/0"
+  next_hop_gateway = "default-internet-gateway"
+  priority         = 1000
+  tags             = [var.public_route_tag]
+}
+
+resource "google_compute_route" "private_route" {
+  name              = "private-route"
+  network           = google_compute_network.vpc.name
+  dest_range        = "0.0.0.0/0"
+  next_hop_instance = var.nat_link
+  priority          = 1000
+  tags              = [var.private_route_tag]
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -3,12 +3,6 @@ variable "env" {
   type        = string
 }
 
-variable "region" {
-  description = "GCP region"
-  type        = string
-  default     = "asia-northeast3"
-}
-
 variable "subnets" {
   description = "subnet setting. key=name, value={ cidr}"
   type = map(object({

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -10,9 +10,24 @@ variable "region" {
 }
 
 variable "subnets" {
-  description = "subnet setting. key=name, value={ cidr, type }"
-  type        = map(object({
+  description = "subnet setting. key=name, value={ cidr}"
+  type = map(object({
     cidr = string
-    type = string # public or private
   }))
+}
+
+
+variable "nat_link" {
+  description = "nat instance의 self_link"
+  type        = string
+}
+
+variable "private_route_tag" {
+  description = "private route tags"
+  type = string
+}
+
+variable "public_route_tag" {
+  description = "public route tags"
+  type = string
 }


### PR DESCRIPTION
## 📝 PR 개요
원래 분리된 public, private subnet을 합쳤다.
특정 태그를 기반으로 ig와 연결된 route, nat와 연결된 route resoure를 생성했다.
tag의 경우 network 외부에서 가져온다. (public, private) 태그

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- private, public subnet 분리 제거
- internet gateway route 추가
- nat route 추가
- 각 route에 맞는 tag를 변수로 가져와 적용
- tag 지정하여 인터넷 연결

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
 #31 
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->