### PR TITLE
Feat: dns module 작성

### DIFF
--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -1,0 +1,7 @@
+resource "google_compute_managed_ssl_certificate" "ssl_cert" {
+  name = var.name
+
+  managed {
+    domains = var.domains
+  }
+}

--- a/modules/dns/outputs.tf
+++ b/modules/dns/outputs.tf
@@ -1,0 +1,9 @@
+output "ssl_certificate_id" {
+  description = "SSL certificate의 id"
+  value       = google_compute_managed_ssl_certificate.ssl_cert.id
+}
+
+output "ssl_certificate_self_link" {
+  description = "SSL certificate의 self-link"
+  value       = google_compute_managed_ssl_certificate.ssl_cert.self_link
+}

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -1,0 +1,9 @@
+variable "name" {
+  description = "Name of the SSL certificate resource"
+  type        = string
+}
+
+variable "domains" {
+  description = "SSL certificate인증을 받을 도메인 리스트"
+  type        = list(string)
+}


### PR DESCRIPTION
## 📝 PR 개요
gabia와 연결할 dns 모듈을 작성한다.

## 🔍 변경사항
- dns 모듈 파일을 생성했다.
- ssl_certificate 기능 추가

## 🔗 관련 이슈
 #17

## 🚨 주의사항
gcp는 ssl 등록은 gcp에서 하지만 인증은 실제 리소스와 연결될때 진행된다고 합니다.