### PR TITLE
Feat: cloud_storage module 작성 [0%] 

### DIFF
--- a/modules/cloud_storage/main.tf
+++ b/modules/cloud_storage/main.tf
@@ -1,6 +1,6 @@
 # 이미지 저장용 GCS 버킷 생성
 resource "google_storage_bucket" "image_bucket" {
-  name          = var.bucket_name
+  name          = "${var.bucket_name}-${var.env}"
   location      = var.location
   force_destroy = var.force_destroy
 
@@ -35,3 +35,10 @@ resource "google_storage_bucket_iam_member" "backend_full_access" {
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${var.backend_service_account_email}"
 }
+
+# GCS 버킷을 로드 밸런서에 연결하고 CDN 기능 사용
+resource "google_compute_backend_bucket" "image_backend_bucket" { 
+  name        = "${var.bucket_name}-cdn-backend-${var.env}" 
+  bucket_name = google_storage_bucket.image_bucket.name
+  enable_cdn  = true 
+} 

--- a/modules/cloud_storage/main.tf
+++ b/modules/cloud_storage/main.tf
@@ -1,0 +1,23 @@
+# 이미지 저장용 GCS 버킷 생성
+resource "google_storage_bucket" "image_bucket" {
+  name          = var.bucket_name
+  location      = var.location
+  force_destroy = var.force_destroy
+
+  uniform_bucket_level_access = true 
+
+  cors { 
+    origin          = var.cors_origins
+    method          = ["GET", "HEAD"]
+    response_header = ["Content-Type"]
+    max_age_seconds = 3600
+  }
+
+  labels = {
+    name        = "${var.env}-image-storage-bucket" 
+    environment = var.env                           
+    component   = "backend"                         
+    type        = "gcs"                             
+    managed_by  = "terraform"                       
+  }
+}

--- a/modules/cloud_storage/main.tf
+++ b/modules/cloud_storage/main.tf
@@ -21,3 +21,17 @@ resource "google_storage_bucket" "image_bucket" {
     managed_by  = "terraform"                       
   }
 }
+
+# 이미지 공개 읽기 권한 설정
+resource "google_storage_bucket_iam_member" "public_access" { 
+  bucket = google_storage_bucket.image_bucket.name
+  role   = "roles/storage.objectViewer"
+  member = "allUsers" 
+}
+
+# 백엔드 서비스 계정에 전체 권한 부여
+resource "google_storage_bucket_iam_member" "backend_full_access" { 
+  bucket = google_storage_bucket.image_bucket.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${var.backend_service_account_email}"
+}

--- a/modules/cloud_storage/outputs.tf
+++ b/modules/cloud_storage/outputs.tf
@@ -1,0 +1,4 @@
+output "backend_bucket_id" {
+  description = "CDN 대상이 되는 Backend Bucket의 self_link"
+  value       = google_compute_backend_bucket.image_backend_bucket.id
+}

--- a/modules/cloud_storage/outputs.tf
+++ b/modules/cloud_storage/outputs.tf
@@ -1,4 +1,4 @@
-output "backend_bucket_id" {
+output "cdn_backend_bucket_self_link" {
   description = "CDN 대상이 되는 Backend Bucket의 self_link"
-  value       = google_compute_backend_bucket.image_backend_bucket.id
+  value       = google_compute_backend_bucket.image_backend_bucket.self_link
 }

--- a/modules/cloud_storage/variables.tf
+++ b/modules/cloud_storage/variables.tf
@@ -24,3 +24,8 @@ variable "env" {
   description = "배포 환경 구분 값 (dev, prod 등)"
   type        = string
 }
+
+variable "backend_service_account_email" {
+  description = "이미지를 업로드할 백엔드 서비스 계정의 이메일 주소"
+  type        = string
+}

--- a/modules/cloud_storage/variables.tf
+++ b/modules/cloud_storage/variables.tf
@@ -1,0 +1,26 @@
+variable "bucket_name" {
+  description = "이미지를 저장할 GCS 버킷 이름"
+  type        = string
+}
+
+variable "location" {
+  description = "GCS 버킷이 생성될 리전 (예: ASIA, US 등)"
+  type        = string
+  default     = "ASIA"
+}
+
+variable "force_destroy" {
+  description = "버킷 삭제 시 내부 객체도 함께 삭제할지 여부 (운영 환경에서는 false 권장)"
+  type        = bool
+  default     = false
+}
+
+variable "cors_origins" {
+  description = "브라우저에서 허용할 CORS 요청 origin"
+  type        = list(string)
+}
+
+variable "env" {
+  description = "배포 환경 구분 값 (dev, prod 등)"
+  type        = string
+}


### PR DESCRIPTION
## 📝 PR 개요
이미지 저장 및 정적 콘텐츠 제공을 위한 GCS 버킷, 공개 접근 권한, 백엔드 서비스 계정 권한, CDN용 backend_bucket 구성을 추가했습니다.

## 🔍 변경사항
- 이미지 저장용 GCS 버킷 생성
- google_storage_bucket_iam_member
  - 모든 사용자에게 공개 읽기 권한 부여
  - 백엔드 서비스 계정에 전체 권한 부여
- GCS 버킷을 Cloud CDN 백엔드로 등록
- cdn_backend_bucket_slef_link : CDN 백엔드로 등록된 GCS 버킷의 self_link 출력

## 🔗 관련 이슈
close #20 

## 🚨 주의사항
- force_destroy가 true인 경우, 버킷 삭제 시 내부 객체도 삭제됩니다. 운영 환경에서는 false 권장