### PR TITLE
Feat: google_compute_backend 분기 처리

### DIFF
--- a/modules/dns/main.tf
+++ b/modules/dns/main.tf
@@ -39,10 +39,6 @@ resource "google_compute_backend_service" "svc" {
   timeout_sec = 10
 }
 
-locals {
-  fallback_service_key = "be"  # 확실히 존재하는 key
-}
-
 # HTTPS용 URL Map (호스트 기반 매칭 + default_service)
 resource "google_compute_url_map" "https_map" {
   name = "https-map-${var.env}"
@@ -67,7 +63,7 @@ resource "google_compute_url_map" "https_map" {
     }
   }
 
-  default_service = google_compute_backend_service.svc[local.fallback_service_key].self_link
+  default_service = google_compute_backend_service.svc[var.fallback_service_key].self_link
 }
 
 # HTTPS Proxy & Forwarding (443)

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -32,3 +32,13 @@ variable "cdn_backend_bucket_self_link" {
   description = "cloud_storage 모듈에서 전달받은 backend_bucket self link (cdn용)"
   type        = string
 }
+
+variable "fallback_service_key" {
+  description = "host 미매칭 시 기본 라우팅 대상 서비스 키"
+  type        = string
+
+  validation {
+    condition     = contains(keys(var.services), var.fallback_service_key)
+    error_message = "fallback_service_key 값은 services 변수 내의 키 중 하나여야 합니다."
+  }
+}

--- a/modules/dns/variables.tf
+++ b/modules/dns/variables.tf
@@ -27,3 +27,8 @@ variable "services" {
     port_name      = string # module.be.port_name
   }))
 }
+
+variable "cdn_backend_bucket_self_link" {
+  description = "cloud_storage 모듈에서 전달받은 backend_bucket self link (cdn용)"
+  type        = string
+}


### PR DESCRIPTION
## 📝 PR 개요
Cloud CDN을 사용하는 cdn 서비스에 대해 google_compute_backend_service 대신 google_compute_backend_bucket을 사용하도록 로직을 분기 처리하였습니다.

## 🔍 변경사항
- google_compute_backend_service 정의 시 cdn 서비스 제외
- path_matcher에서 cdn인 경우 var.cdn_backend_bucket_self_link를 사용하여 backend_bucket 연결
- fallback 서비스 처리 시 cdn 제외
- 방화벽 설정에서 target_tags에 cdn 제외

## 🔗 관련 이슈
Close #42 

## 🚨 주의사항
cdn_backend_bucket_self_link는 상위 모듈에서 정확하게 전달되어야 하며, 값이 없을 경우 배포 실패 가능합니다.