### PR TITLE
Feat: GCS 버킷 보안 강화

### DIFF
--- a/modules/cloud_storage/main.tf
+++ b/modules/cloud_storage/main.tf
@@ -42,9 +42,10 @@ resource "google_compute_backend_bucket" "image_backend_bucket" {
   enable_cdn  = true 
 } 
 
-# 이미지 공개 읽기 권한 설정
-resource "google_storage_bucket_iam_member" "public_access" { 
+data "google_project" "project" {}
+
+resource "google_storage_bucket_iam_member" "cdn_access" {
   bucket = google_storage_bucket.image_bucket.name
   role   = "roles/storage.objectViewer"
-  member = "allUsers" 
+  member = "serviceAccount:service-${data.google_project.project.number}@gs-project-accounts.iam.gserviceaccount.com"
 }

--- a/modules/cloud_storage/main.tf
+++ b/modules/cloud_storage/main.tf
@@ -13,6 +13,12 @@ resource "google_storage_bucket" "image_bucket" {
     max_age_seconds = 3600
   }
 
+  public_access_prevention = "enforced"
+
+  versioning {
+    enabled = true
+  } 
+
   labels = {
     name        = "${var.env}-image-storage-bucket" 
     environment = var.env                           


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
보안 강화를 위해 GCS 버킷의 allUsers 공개 접근 권한을 제거하고, Cloud CDN 서비스 계정에게만 객체 조회 권한을 부여하도록 수정했습니다. 또한, 객체 버전 관리 및 공개 접근 차단 정책을 추가해 안전한 스토리지 환경을 구성했습니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- public_access_prevention = "enforced" 추가로 공개 접근 완전 차단
- 객체 변경/삭제 이력 추적을 위한 versioning 기능 활성화
- google_storage_bucket_iam_member "public_access" 제거 후 "cdn_access" 추가
  - CDN 서비스 계정만 roles/storage.objectViewer 권한 부여

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #60 

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
모든 퍼블릭 공개 설정을 차단했기 때문에, 프런트엔드 클라이언트는 반드시 CDN 경유 URL을 통해 이미지를 로드해야 함