### PR TITLE
Fix: Cloud SQL 인스턴스에 VPC 연결 의존성 설정 추가

### DIFF
--- a/modules/cloud_sql/main.tf
+++ b/modules/cloud_sql/main.tf
@@ -17,6 +17,10 @@ resource "google_sql_database_instance" "postgres" {
   }
 
   deletion_protection = var.deletion_protection
+
+  depends_on = [
+    google_service_networking_connection.private_vpc_connection
+  ]
 }
 
 resource "google_sql_database" "default" {


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
Cloud SQL 인스턴스 리소스에 VPC 연결 리소스에 대한 의존성을 명시하여 terraform apply 시 발생하던 생성 순서 오류를 해결했습니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- google_sql_database_instance.postgres 리소스에 depends_on = [google_service_networking_connection.private_vpc_connection] 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #72 

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
해당 수정은 Cloud SQL 인스턴스가 google_service_networking_connection 이후 생성되도록 보장하여, apply 오류를 방지함