### PR TITLE
Hotfix: vpc peering 제거 및 cloud sql에 nat  접근 추가

### DIFF
--- a/envs/dev/main.tf
+++ b/envs/dev/main.tf
@@ -107,8 +107,7 @@ module "cloudsql" {
   db_user             = var.db_user
   db_password         = var.db_password
   backup_bucket_name  = var.backup_bucket_name
-  vpc_self_link       = module.network.vpc_self_link
-  prefix_length       = 24
+  nat_ip_address      = module.nat_bastion.nat_ip
 }
 
 module "cloud_storage" {

--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -8,7 +8,7 @@ terraform {
   }
   backend "gcs" {
     bucket      = "dolpin-terraform-state-29m1t350"
-    prefix     = "prod"
+    prefix      = "prod"
     credentials = "../../secrets/account.json"
   }
 }
@@ -19,16 +19,14 @@ provider "google" {
   region      = var.region
 }
 
-
-
 module "network" {
   source           = "../../modules/network"
   public_route_tag = var.public_tag
   subnets = {
     (var.public_service_name) : { cidr : var.public_cidr }
     (var.be_service_name) : { cidr : var.be_cidr }
-    (var.ai_service_name) : {cidr: var.ai_cidr}
-    (var.fe_service_name) : {cidr: var.fe_cidr}
+    (var.ai_service_name) : { cidr : var.ai_cidr }
+    (var.fe_service_name) : { cidr : var.fe_cidr }
   }
   env = var.env
 }
@@ -41,12 +39,12 @@ module "dns" {
   fallback_service_key         = var.be_service_name
   domains                      = [var.be_domain, var.bucket_domain, var.ai_domain, var.fe_domain]
   network                      = module.network.vpc_self_link
-  services = { 
+  services = {
     (var.be_service_name) : {
-    domain         = var.be_domain
-    instance_group = module.be.instance_group
-    health_check   = module.be.health_check
-    port_name      = var.be_service_name
+      domain         = var.be_domain
+      instance_group = module.be.instance_group
+      health_check   = module.be.health_check
+      port_name      = var.be_service_name
     }
     (var.bucket_service_name) : {
       domain         = var.bucket_domain
@@ -108,24 +106,23 @@ module "cloudsql" {
   db_name             = var.db_name
   db_user             = var.db_user
   db_password         = var.db_password
-  backup_bucket_name = var.backup_bucket_name
-  vpc_self_link = module.network.vpc_self_link
-  prefix_length = 24
+  backup_bucket_name  = var.backup_bucket_name
+  nat_ip_address      = module.nat_bastion.nat_ip
 }
 
 module "cloud_storage" {
   source = "../../modules/cloud_storage"
 
-  env                            = var.env
-  bucket_name                    = var.bucket_name
-  location                       = "ASIA"
-  force_destroy                  = true
-  cors_origins                   = [var.cors_origin]
-  backend_service_account_email  = var.backend_service_account_email
+  env                           = var.env
+  bucket_name                   = var.bucket_name
+  location                      = "ASIA"
+  force_destroy                 = true
+  cors_origins                  = [var.cors_origin]
+  backend_service_account_email = var.backend_service_account_email
 }
 
 module "ai" {
-  source = "../../modules/ai"
+  source            = "../../modules/ai"
   env               = var.env
   network           = module.network.vpc_self_link
   subnetwork        = module.network.subnet_self_links[var.ai_service_name]

--- a/modules/cloud_sql/variables.tf
+++ b/modules/cloud_sql/variables.tf
@@ -56,13 +56,7 @@ variable "backup_bucket_name" {
   type = string
 }
 
-variable "vpc_self_link" {
-  description = "Cloud SQL과 VPC Peering 연결을 구성할 때 필요한 vpc의 self_link 값"
-  type        = string
-}
-
-variable "prefix_length" {
-  description = "VPC Peering을 위해 예약할 IP 주소 범위의 크기 (i.e., 24 (for /24))"
-  type        = number
-  default     = 24
+variable "nat_ip_address" {
+  description = "nat의 ip 주소"
+  type = string
 }


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
vpc peering으로 인한 에러를 수정 및 cloud sql 연결점 추가

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- vpc peering 제거
- cloud sql public ip 할당
- 연결 가능 범위에 nat ip 주소 추가

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
 #74

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
vpc 내부에서는 ip 호출로 통신하고 local에서는 cloud sql auth proxy를 통해 접근할 계획입니다.