### PR TITLE
Hotfix: be 모듈에 cloudsql,5432 허용 방화벽 설정 추가

### DIFF
--- a/envs/prod/main.tf
+++ b/envs/prod/main.tf
@@ -95,6 +95,7 @@ module "be" {
   env                  = var.env
   private_route_tag    = var.private_tag
   network              = module.network.vpc_self_link
+  cloudsql_ip_address  = module.cloudsql.cloudsql_public_ip
 }
 
 module "cloudsql" {

--- a/modules/be/main.tf
+++ b/modules/be/main.tf
@@ -89,7 +89,21 @@ resource "google_compute_firewall" "lb_to_be" {
     "130.211.0.0/22",
     "35.191.0.0/16",
   ]
-  target_tags   = [local.be_tag]
+  target_tags = [local.be_tag]
+}
+
+resource "google_compute_firewall" "be_to_cloudsql_public" {
+  name    = "cloudsql-to-be-firewall-${var.env}"
+  network = var.network
+  direction = "INGRESS"
+
+  allow {
+    protocol = "tcp"
+    ports    = ["5432"]
+  }
+
+  source_tags        = [local.be_tag]
+  destination_ranges = [var.cloudsql_ip_address]
 }
 
 # BE 인스턴스 묶을 인스턴스 그룹 (Named Port 설정)

--- a/modules/be/variables.tf
+++ b/modules/be/variables.tf
@@ -52,3 +52,7 @@ variable "bastion_tag" {
   description = "bastion tag"
   type = string
 }
+variable "cloudsql_ip_address" {
+  description = "cloudsql의 public ip"
+  type = string
+}

--- a/modules/cloud_sql/outputs.tf
+++ b/modules/cloud_sql/outputs.tf
@@ -1,4 +1,4 @@
-output "cloudsql_private_ip" {
-  description = "Private IP address of the Cloud SQL PostgreSQL instance"
-  value       = google_sql_database_instance.postgres.private_ip_address
+output "cloudsql_public_ip" {
+  description = "cloud sql의 공개 ip 주소"
+  value       = google_sql_database_instance.postgres.public_ip_address
 }


### PR DESCRIPTION
Hotfix: be 모듈에 cloudsql,5432 허용 방화벽 설정 추가## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- be module be tag 기반 cloud sql ip의 5432를 허용하는 방화벽 설정 생성

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
#79
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->