### PR TITLE
Feat: FE, BE 서비스용 Dockerfile 작성

### DIFF
--- a/modules/gar/main.tf
+++ b/modules/gar/main.tf
@@ -1,0 +1,36 @@
+resource "google_artifact_registry_repository" "this" {
+  location      = var.location
+  repository_id = "dolpin-docker-image-${var.env}"
+  format        = var.format
+  mode          = "STANDARD_REPOSITORY"
+
+  dynamic "docker_config" {
+    for_each = var.format == "DOCKER" ? [1] : []
+    content {
+      immutable_tags = var.immutable_tags
+    }
+  }
+
+  dynamic "cleanup_policies" {
+    for_each = var.cleanup_policies
+    content {
+      id     = cleanup_policies.value.id
+      action = cleanup_policies.value.action
+      condition {
+        tag_state    = lookup(cleanup_policies.value.condition, "tag_state", null)
+        tag_prefixes = lookup(cleanup_policies.value.condition, "tag_prefixes", null)
+        older_than   = lookup(cleanup_policies.value.condition, "older_than", null)
+        newer_than   = lookup(cleanup_policies.value.condition, "newer_than", null)
+      }
+    }
+  }
+
+  labels = {
+    Name        = "artifact-repo-${var.env}"  
+    component   = "backend"                          
+    env         = var.env                             
+    type        = "artifact-registry"                 
+    managed_by  = "terraform"                        
+    service     = "backend"                           
+  }
+}

--- a/modules/gar/main.tf
+++ b/modules/gar/main.tf
@@ -26,7 +26,7 @@ resource "google_artifact_registry_repository" "this" {
   }
 
   labels = {
-    Name        = "artifact-repo-${var.env}"  
+    name        = "artifact-repo-${var.env}"  
     component   = "backend"                          
     env         = var.env                             
     type        = "artifact-registry"                 

--- a/modules/gar/variables.tf
+++ b/modules/gar/variables.tf
@@ -1,0 +1,43 @@
+variable "location" {
+  type        = string
+  description = "Artifact Registry 저장소의 리전"
+  default     = "asia-northeast3"
+}
+
+variable "env" {
+  type        = string
+  description = "env"
+}
+
+variable "format" {
+  type        = string
+  description = "저장소 형식 (예: DOCKER, MAVEN, NPM)"
+  default     = "DOCKER"
+}
+
+variable "immutable_tags" {
+  type        = bool
+  description = "DOCKER 저장소에서 태그 불변성 설정"
+  default     = false
+}
+
+variable "cleanup_policies" {
+  type = list(object({
+    id     = string
+    action = string
+    condition = optional(object({
+      tag_state    = optional(string)
+      tag_prefixes = optional(list(string))
+      older_than   = optional(string)
+      newer_than   = optional(string)
+    }))
+  }))
+  description = "자동 삭제 정책 목록"
+  default     = []
+}
+
+variable "labels" {
+  type        = map(string)
+  description = "저장소에 붙일 라벨"
+  default     = {}
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
Docker 이미지를 저장하기 위한 Artifact Registry를 모듈화하여 생성하였습니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- 저장소 ID : dolpin-docker-image-${var.env}
- immutable_tags : true일 경우 동일 태그로 이미지 덮어쓰기가 불가능
- cleanup_polices 블록을 통해 자동 삭제/보존 조건 설정 가능

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
Closes #56 

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->
- cleanup_polices는 아래와 같은 형식으로 입력 가능합니다. 
    ```bash
    cleanup_policies = [
      {
        id     = "delete-untagged"
        action = "DELETE"
        condition = {
          tag_state = "UNTAGGED"
        }
      }
    ]
    ```