### PR TITLE
Fix: fe,be,ai의 startup.sh에서 유효하지 않은 패키지 삭제

### DIFF
--- a/modules/ai/scripts/startup.sh
+++ b/modules/ai/scripts/startup.sh
@@ -31,22 +31,7 @@ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.clou
     sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list > /dev/null
 
 sudo apt-get update -y
-sudo apt-get install -y google-cloud-sdk google-cloud-sdk-artifact-registry-credential-helper
-
-echo "▶ peter 계정 Docker Credential Helper 구성"
-sudo mkdir -p /home/peter/.docker
-sudo tee /home/peter/.docker/config.json > /dev/null <<EOF
-{
-  "credHelpers": {
-    "asia-northeast3-docker.pkg.dev": "gcloud"
-  }
-}
-EOF
-sudo chown -R peter:peter /home/peter/.docker
-
-echo "▶ root 계정에도 동일한 docker config 복사"
-sudo mkdir -p /root/.docker
-sudo cp /home/peter/.docker/config.json /root/.docker/config.json
+sudo apt-get install -y google-cloud-sdk
 
 echo "▶ peter 계정에 docker 그룹 권한 부여"
 sudo usermod -aG docker peter

--- a/modules/be/scripts/startup.sh
+++ b/modules/be/scripts/startup.sh
@@ -33,22 +33,7 @@ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.clou
     sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list > /dev/null
 
 sudo apt-get update -y
-sudo apt-get install -y google-cloud-sdk google-cloud-sdk-artifact-registry-credential-helper
-
-echo "▶ peter 계정 Docker Credential Helper 구성"
-sudo mkdir -p /home/peter/.docker
-sudo tee /home/peter/.docker/config.json > /dev/null <<EOF
-{
-  "credHelpers": {
-    "asia-northeast3-docker.pkg.dev": "gcloud"
-  }
-}
-EOF
-sudo chown -R peter:peter /home/peter/.docker
-
-echo "▶ root 계정에도 동일한 docker config 복사"
-sudo mkdir -p /root/.docker
-sudo cp /home/peter/.docker/config.json /root/.docker/config.json
+sudo apt-get install -y google-cloud-sdk
 
 echo "▶ peter 계정에 docker 그룹 권한 부여"
 sudo usermod -aG docker peter

--- a/modules/fe/scripts/startup.sh
+++ b/modules/fe/scripts/startup.sh
@@ -36,22 +36,7 @@ echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.clou
     sudo tee /etc/apt/sources.list.d/google-cloud-sdk.list > /dev/null
 
 sudo apt-get update -y
-sudo apt-get install -y google-cloud-sdk google-cloud-sdk-artifact-registry-credential-helper
-
-echo "▶ peter 계정 Docker Credential Helper 구성"
-sudo mkdir -p /home/peter/.docker
-sudo tee /home/peter/.docker/config.json > /dev/null <<EOF
-{
-  "credHelpers": {
-    "asia-northeast3-docker.pkg.dev": "gcloud"
-  }
-}
-EOF
-sudo chown -R peter:peter /home/peter/.docker
-
-echo "▶ root 계정에도 동일한 docker config 복사"
-sudo mkdir -p /root/.docker
-sudo cp /home/peter/.docker/config.json /root/.docker/config.json
+sudo apt-get install -y google-cloud-sdk
 
 echo "▶ peter 계정에 docker 그룹 권한 부여"
 sudo usermod -aG docker peter


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
현재 startup-script에서 google-cloud-sdk-artifact-registry-credential-helper를 설치하려다 실패하면서 전체 스크립트가 중단. 
패키지 설치 내용 삭제
## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- apit install 시 google-cloud-sdk-artifact-registry-credential-helper 삭제
- 이후 필요없는 내용 삭제

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g.  Closes #123) -->
  #101
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->