### PR TITLE
Refactor: db 비밀번호 고정 값 사용

### DIFF
--- a/envs/static/.terraform.lock.hcl
+++ b/envs/static/.terraform.lock.hcl
@@ -20,3 +20,22 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version = "3.7.2"
+  hashes = [
+    "h1:KG4NuIBl1mRWU0KD/BGfCi1YN/j3F7H4YgeeM7iSdNs=",
+    "zh:14829603a32e4bc4d05062f059e545a91e27ff033756b48afbae6b3c835f508f",
+    "zh:1527fb07d9fea400d70e9e6eb4a2b918d5060d604749b6f1c361518e7da546dc",
+    "zh:1e86bcd7ebec85ba336b423ba1db046aeaa3c0e5f921039b3f1a6fc2f978feab",
+    "zh:24536dec8bde66753f4b4030b8f3ef43c196d69cccbea1c382d01b222478c7a3",
+    "zh:29f1786486759fad9b0ce4fdfbbfece9343ad47cd50119045075e05afe49d212",
+    "zh:4d701e978c2dd8604ba1ce962b047607701e65c078cb22e97171513e9e57491f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b8434212eef0f8c83f5a90c6d76feaf850f6502b61b53c329e85b3b281cba34",
+    "zh:ac8a23c212258b7976e1621275e3af7099e7e4a3d4478cf8d5d2a27f3bc3e967",
+    "zh:b516ca74431f3df4c6cf90ddcdb4042c626e026317a33c53f0b445a3d93b720d",
+    "zh:dc76e4326aec2490c1600d6871a95e78f9050f9ce427c71707ea412a2f2f1a62",
+    "zh:eac7b63e86c749c7d48f527671c7aee5b4e26c10be6ad7232d6860167f99dbb0",
+  ]
+}

--- a/envs/static/main.tf
+++ b/envs/static/main.tf
@@ -30,3 +30,9 @@ module "tf_automation" {
   envs_parameter     = var.envs_parameter
   backup_bucket_name = var.backup_bucket_name
 }
+
+module "secret" {
+  source = "./modules/secret"
+  db_envs = var.db_envs
+  db_username = var.db_usernames
+}

--- a/envs/static/modules/secret/main.tf
+++ b/envs/static/modules/secret/main.tf
@@ -1,0 +1,26 @@
+resource "random_password" "db_password" {
+  for_each          = var.db_envs
+  length            = 16
+  special           = true
+  override_special  = "!@#%^&*()-_+[]{}<>?"
+}
+
+resource "google_secret_manager_secret" "cloudsql_password" {
+  for_each  = var.db_envs
+  secret_id = "cloudsql-dolpinuser-password-${each.key}"
+  replication {
+    auto {}
+  }
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_secret_manager_secret_version" "cloudsql_password_version" {
+  for_each    = var.db_envs
+  secret      = google_secret_manager_secret.cloudsql_password[each.key].id
+  secret_data = random_password.db_password[each.key].result
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/envs/static/modules/secret/variables.tf
+++ b/envs/static/modules/secret/variables.tf
@@ -1,0 +1,8 @@
+variable "db_envs" {
+  type = set(string)
+}
+
+variable "db_username" {
+  type = string
+  description = "DB 사용자 이름"
+}

--- a/envs/static/variables.tf
+++ b/envs/static/variables.tf
@@ -105,3 +105,13 @@ variable "backup_bucket_name" {
   description = "백업에 사용할 버킷 이름"
   default     = "static-backup-bucket"
 }
+
+variable "db_envs" {
+  type    = set(string)
+  default = ["dev", "prod"]
+}
+
+variable "db_usernames" {
+  type        = string
+  default = "dolpinuser"
+}

--- a/modules/cloud_sql/data.tf
+++ b/modules/cloud_sql/data.tf
@@ -1,0 +1,3 @@
+data "google_secret_manager_secret_version" "db_password" {
+  secret = "projects/${var.project_id}/secrets/cloudsql-dolpinuser-password-${var.env}/versions/latest"
+}

--- a/modules/cloud_sql/variables.tf
+++ b/modules/cloud_sql/variables.tf
@@ -54,3 +54,8 @@ variable "nat_ip_address" {
   description = "nat의 ip 주소"
   type = string
 }
+
+variable "project_id" {
+  description = "프로젝트 id"
+  type = string
+}


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
기존 매번 변경되는 db 비밀번호를 static 환경에서 생성하고 db에서 참조하는 식으로 변경한다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- static 환경에 cloud sql 비밀번호 생성
- database sql secret manager 참조 방식으로 변경

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
- #121 
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->