### PR TITLE
Fix: Jenkins가 최신 백업 파일로 복원

### DIFF
--- a/envs/shared/modules/jenkins/scripts/startup.sh
+++ b/envs/shared/modules/jenkins/scripts/startup.sh
@@ -56,7 +56,8 @@ sudo docker run --rm -v jenkins_home:/data busybox true
 
 JENKINS_HOME="/var/lib/docker/volumes/jenkins_home/_data"
 
-LATEST_BACKUP=$(gsutil ls gs://backup-dolpin-dev/jenkins-backups/ | sort | tail -n 1)
+LATEST_BACKUP=$(gsutil ls -l gs://backup-dolpin-dev/jenkins-backups/ | \
+  grep -v TOTAL | sort -k2,3 | tail -n 1 | awk '{print $NF}')
 
 touch /tmp/restore.lock
 


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
Jenkins 데이터 복원을 진행할 때, 최신 백업 파일이 아니라 사전순으로 가장 뒤의 파일로 진행하는 문제를 해결하였습니다.

## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- 백업 버킷에서 사전순 정렬하여 마지막 파일로 백업 -> 시간순 정렬하여 최신 파일로 백업

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
#140 

## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->