### PR TITLE
Fix: monitoring 모듈 start script 버그 수정

### DIFF
--- a/envs/shared/modules/monitoring/files/docker-compose.yml
+++ b/envs/shared/modules/monitoring/files/docker-compose.yml
@@ -143,7 +143,7 @@ services:
     depends_on:
       - cloudsql-proxy-prod
     ports:
-      - "9187:9187"
+      - "9188:9187"
     environment:
       - DATA_SOURCE_NAME=postgresql://dolpinuser:"${PROD_DB_PW}"@cloudsql-proxy-prod:5433/dolpin?sslmode=disable
       


### PR DESCRIPTION
## 📝 PR 개요
<!-- 이 PR이 해결하는 문제나 추가하는 기능에 대한 간략한 설명 -->
monitoring 모듈의 startup script의 docker compose의 postgres-exporter 포트 번호를 수정한다.
## 🔍 변경사항
<!-- 주요 변경사항 목록 (불릿 포인트) -->
- docker compose의 postgres-exporter 포트 번호 수

## 🔗 관련 이슈
<!-- 관련된 이슈 링크 (e.g. Closes #123) -->
 #142
## 🚨 주의사항
<!-- 리뷰어가 알아야 할 주의사항이나 고려사항 -->